### PR TITLE
Fix for attaching multiple behaviours with defaults

### DIFF
--- a/lib/behaviours.coffee
+++ b/lib/behaviours.coffee
@@ -65,7 +65,7 @@ share.attach = attach = (behaviours, options...) ->
       if Match.test behaviour, Function
         context.options ?= {}
 
-        behaviour.apply context, {}
+        behaviour.call context, {}
 
         behaviourObject?.collections ?= []
         behaviourObject?.collections.push @_name


### PR DESCRIPTION
In the example, it states you can attach multiple behaviours with their defaults by using `CollectionBehaviours.attach` with multiple behaviours in an Array as the second parameter.

```
CollectionBehaviours.attach(Rates, ["timestampable", "softremovable"]);
```

Unfortunately, this does not work with the current code because it's trying to call `apply` with an Object.  This PR will fix this functionality to work properly.
